### PR TITLE
Remove knex as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "knex": "^0.21.1"
   },
   "peerDependencies": {
-    "knex": "^0.21.1",
     "meyer": "^1.1.1"
   },
   "husky": {


### PR DESCRIPTION
Knex is already installed by this package in the dependencies.